### PR TITLE
Import senkyoshi upload

### DIFF
--- a/konbata.example.yml
+++ b/konbata.example.yml
@@ -1,2 +1,7 @@
 # Generally looks like /Applications/LibreOffice.app/Contents/MacOS/soffice
 :libre_office_path: <LibreOffice Path>
+
+:canvas_url: <canvas instance api url>
+:canvas_token: <canvas token>
+:account_id: <account id>
+:request_timeout: <request timeout seconds>

--- a/konbata.example.yml
+++ b/konbata.example.yml
@@ -1,7 +1,17 @@
+# --LibreOffice setup--
+
 # Generally looks like /Applications/LibreOffice.app/Contents/MacOS/soffice
 :libre_office_path: <LibreOffice Path>
 
-:canvas_url: <canvas instance api url>
+# --Canvas upload setup--
+:canvas_url: <canvas instance api url> # e.g. http://<canvas-url>/api
+
+# Found in Account >> Profile >> Generate Access Token
 :canvas_token: <canvas token>
+
+# Fourse number found at specific course url:
+#   http://<canvas-url>/accounts/_HERE_
 :account_id: <account id>
+
+# Leave empty for DEFAULT_TIMEOUT
 :request_timeout: <request timeout seconds>

--- a/konbata.gemspec
+++ b/konbata.gemspec
@@ -33,5 +33,8 @@ Gem::Specification.new do |spec|
     ["nokogiri", "~> 1.6.6"],
     ["fileutils", "~> 0.7"],
     ["activesupport", "~> 4.2"],
+    ["pandarus", "~> 0.6.8"],
+    ["rubyzip", "~> 1.2.1"],
+    ["rest-client", "~> 2.0"],
   ].each { |d| spec.add_runtime_dependency(*d) }
 end

--- a/lib/konbata.rb
+++ b/lib/konbata.rb
@@ -1,8 +1,10 @@
 require "canvas_cc"
+require "zip"
 
 require "konbata/configuration"
 require "konbata/reporter"
-require "konbata/models/course"
+require "konbata/models/canvas_course"
+require "konbata/models/upload_course"
 
 module Konbata
   INPUT_DIR = "sources".freeze
@@ -58,5 +60,11 @@ module Konbata
       courses[course] ||= Hash.new([])
       courses[course][volume] |= [file]
     end
+  end
+
+  def self.initialize_course(canvas_file_path)
+    metadata = Konbata::UploadCourse.metadata_from_file(canvas_file_path)
+    course = Konbata::UploadCourse.from_metadata(metadata)
+    course.upload_content(canvas_file_path)
   end
 end

--- a/lib/konbata/configuration.rb
+++ b/lib/konbata/configuration.rb
@@ -2,13 +2,24 @@ require "yaml"
 
 module Konbata
   class Configuration
+
+    attr_accessor :canvas_url
+    attr_accessor :canvas_token
+    attr_accessor :account_id
+    attr_accessor :request_timeout
     attr_reader :libre_office_path
+    DEFAULT_TIMEOUT = 1_800 # 30 minutes
 
     def initialize
-      @libre_office_path = Configuration.config[:libre_office_path]
+      @canvas_url = Configuration._config[:canvas_url]
+      @canvas_token = Configuration._config[:canvas_token]
+      @account_id = Configuration._config[:account_id] || :self
+      @request_timeout =
+        Configuration._config[:request_timeout] || DEFAULT_TIMEOUT
+      @libre_office_path = Configuration._config[:libre_office_path]
     end
 
-    def self.config
+    def self._config
       @config ||= if File.exists? "konbata.yml"
                     YAML::safe_load(File.read("konbata.yml"), [Symbol])
                   else

--- a/lib/konbata/configuration.rb
+++ b/lib/konbata/configuration.rb
@@ -2,10 +2,10 @@ require "yaml"
 
 module Konbata
   class Configuration
-    attr_accessor :canvas_url
-    attr_accessor :canvas_token
-    attr_accessor :account_id
-    attr_accessor :request_timeout
+    attr_reader :canvas_url
+    attr_reader :canvas_token
+    attr_reader :account_id
+    attr_reader :request_timeout
     attr_reader :libre_office_path
     DEFAULT_TIMEOUT = 1_800 # 30 minutes
 

--- a/lib/konbata/configuration.rb
+++ b/lib/konbata/configuration.rb
@@ -2,7 +2,6 @@ require "yaml"
 
 module Konbata
   class Configuration
-
     attr_accessor :canvas_url
     attr_accessor :canvas_token
     attr_accessor :account_id

--- a/lib/konbata/models/canvas_course.rb
+++ b/lib/konbata/models/canvas_course.rb
@@ -1,4 +1,5 @@
 require "canvas_cc"
+require "konbata/reporter"
 require "konbata/models/module"
 require "konbata/models/cover_page_file"
 require "konbata/models/glossary_file"
@@ -57,10 +58,24 @@ module Konbata
 
         source_files.each do |source_file|
           source_file.convert(canvas_course, canvas_module)
+
+          Konbata::Reporter.complete_source_file(
+            _source_file_index(source_file),
+            _source_files_count,
+          )
         end
 
         canvas_course.canvas_modules << canvas_module
       end
+    end
+
+    def _source_files_count
+      @volumes.reduce(0) { |total, (_volume, files)| total + files.size }
+    end
+
+    def _source_file_index(source_file)
+      @all_files ||= @volumes.reduce([]) { |all, (_volume, files)| all + files }
+      @all_files.index(source_file)
     end
   end
 end

--- a/lib/konbata/models/canvas_course.rb
+++ b/lib/konbata/models/canvas_course.rb
@@ -1,5 +1,4 @@
 require "canvas_cc"
-require "konbata/reporter"
 require "konbata/models/module"
 require "konbata/models/cover_page_file"
 require "konbata/models/glossary_file"
@@ -58,24 +57,10 @@ module Konbata
 
         source_files.each do |source_file|
           source_file.convert(canvas_course, canvas_module)
-
-          Konbata::Reporter.complete_source_file(
-            _source_file_index(source_file),
-            _source_files_count,
-          )
         end
 
         canvas_course.canvas_modules << canvas_module
       end
-    end
-
-    def _source_files_count
-      @volumes.reduce(0) { |total, (_volume, files)| total + files.size }
-    end
-
-    def _source_file_index(source_file)
-      @all_files ||= @volumes.reduce([]) { |all, (_volume, files)| all + files }
-      @all_files.index(source_file)
     end
   end
 end

--- a/lib/konbata/models/upload_course.rb
+++ b/lib/konbata/models/upload_course.rb
@@ -35,13 +35,14 @@ module Konbata
         token: Konbata.configuration.canvas_token,
       )
     end
+
     ##
     # Find or Create a new CanvasCourse instance from the given metadata
     ##
     def self.from_metadata(metadata)
       course_title = metadata[:title]
-      #TODO: Actually use the course_code somewhere
-      course_code = metadata[:course_code]
+      # TODO: Actually use the course_code somewhere
+      # course_code = metadata[:course_code]
       course_resource = client.create_new_course(
         Konbata.configuration.account_id,
         course: {
@@ -50,6 +51,7 @@ module Konbata
       )
       UploadCourse.new(course_resource)
     end
+    
     ##
     # Create a migration for the course
     # and upload the imscc file to be imported into the course

--- a/lib/konbata/models/upload_course.rb
+++ b/lib/konbata/models/upload_course.rb
@@ -1,0 +1,98 @@
+require "canvas_cc"
+require "pandarus"
+require "rest-client"
+
+module Konbata
+  class UploadCourse
+    attr_reader :canvas_course
+
+    def initialize(course_resource)
+      @course_resource = course_resource
+    end
+
+    ##
+    # Given a filename to a imscc file, extract the necessary metadata
+    # for the course
+    ##
+    def self.metadata_from_file(filename)
+      Zip::File.open(filename) do |file|
+        settings = "course_settings/course_settings.xml"
+        config = file.find_entry(settings).get_input_stream.read
+        doc = Nokogiri::XML(config)
+        {
+          title: doc.at("title").text,
+          course_code: doc.at("course_code").text,
+        }
+      end
+    end
+
+    ##
+    # Create a new pandarus instance to communicate with the canvas server
+    ##
+    def self.client
+      @client ||= Pandarus::Client.new(
+        prefix: Konbata.configuration.canvas_url,
+        token: Konbata.configuration.canvas_token,
+      )
+    end
+    ##
+    # Find or Create a new CanvasCourse instance from the given metadata
+    ##
+    def self.from_metadata(metadata)
+      course_title = metadata[:title]
+      #TODO: Actually use the course_code somewhere
+      course_code = metadata[:course_code]
+      course_resource = client.create_new_course(
+        Konbata.configuration.account_id,
+        course: {
+          name: course_title,
+        },
+      )
+      UploadCourse.new(course_resource)
+    end
+    ##
+    # Create a migration for the course
+    # and upload the imscc file to be imported into the course
+    ##
+    def upload_content(filename)
+      client = UploadCourse.client
+      name = File.basename(filename)
+      # Create a migration for the course and get S3 upload authorization
+      migration = client.
+        create_content_migration_courses(
+          @course_resource.id,
+          :canvas_cartridge_importer,
+          pre_attachment: { name: name },
+        )
+
+      puts "Uploading: #{name}"
+      upload_to_s3(migration, filename)
+      puts "Done uploading: #{name}"
+    end
+
+    def upload_to_s3(migration, filename)
+      File.open(filename, "rb") do |file|
+        # Attach the file to the S3 auth
+        pre_attachment = migration.pre_attachment
+        upload_url = pre_attachment["upload_url"]
+        upload_params = pre_attachment["upload_params"]
+        upload_params[:file] = file
+
+        # Post to S3
+        RestClient::Request.execute(
+          method: :post,
+          url: upload_url,
+          payload: upload_params,
+          timeout: Konbata.configuration.request_timeout,
+        ) do |response|
+          # Post to Canvas
+          RestClient.post(
+            response.headers[:location],
+            nil,
+            Authorization: "Bearer #{Konbata.configuration.canvas_token}",
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/konbata/models/upload_course.rb
+++ b/lib/konbata/models/upload_course.rb
@@ -51,7 +51,7 @@ module Konbata
       )
       UploadCourse.new(course_resource)
     end
-    
+
     ##
     # Create a migration for the course
     # and upload the imscc file to be imported into the course

--- a/lib/konbata/tasks.rb
+++ b/lib/konbata/tasks.rb
@@ -2,24 +2,64 @@ require "rake"
 require "rake/clean"
 require "konbata"
 
+OUTPUT_DIR = "output".freeze
+UPLOAD_DIR = "uploaded".freeze
+
+## Don't change these, these are just getting the last
+## of the folder name for the script below to use
+OUTPUT_NAME = OUTPUT_DIR.split("/").last
+UPLOAD_NAME = UPLOAD_DIR.split("/").last
+CONVERTED_FILES = Rake::FileList.new("#{OUTPUT_DIR}/*.imscc")
+
+##
+# Creates rake tasks that can be ran from the gem.
+#
+# Add this to your Rakefile
+#
+#   require "konbata/tasks"
+#   Senkyoshi::Tasks.install_tasks
+#
+##
+
+def source_for_upload_log(upload_log)
+  CONVERTED_FILES.detect do |f|
+    path = upload_log.pathmap("%{^#{UPLOAD_DIR}/,#{OUTPUT_DIR}/}X")
+    f.ext("") == path
+  end
+end
+
+def make_directories(name, upload_dir)
+  mkdir_p name.pathmap("%d")
+  mkdir_p upload_dir
+end
+
+def log_file(name)
+  sh "touch #{name}"
+  sh "date >> #{name}"
+end
+
 module Konbata
   class Tasks
     extend Rake::DSL if defined? Rake::DSL
 
-    ##
-    # Creates rake tasks that can be ran from the gem.
-    #
-    # Add this to your Rakefile
-    #
-    #   require "konbata/tasks"
-    #   Senkyoshi::Tasks.install_tasks
-    #
-    ##
     def self.install_tasks
       namespace :konbata do
         desc "Generate Canvas courses from folders in source directory."
         task :imscc do
           Konbata.convert_courses
+        end
+
+        desc "Upload converted files to canvas"
+        task upload: CONVERTED_FILES.pathmap(
+          "%{^#{OUTPUT_NAME}/,#{UPLOAD_DIR}/}X.txt",
+        )
+
+        directory UPLOAD_NAME
+
+        rule ".txt" => [->(f) { source_for_upload_log(f) }, UPLOAD_NAME] do |t|
+          make_directories(t.name, UPLOAD_DIR)
+          Konbata.initialize_course(t.source)
+          log_file(t.name)
         end
 
         desc "Destroy output folder."

--- a/lib/konbata/tasks.rb
+++ b/lib/konbata/tasks.rb
@@ -2,14 +2,13 @@ require "rake"
 require "rake/clean"
 require "konbata"
 
-OUTPUT_DIR = "output".freeze
 UPLOAD_DIR = "uploaded".freeze
 
 ## Don't change these, these are just getting the last
 ## of the folder name for the script below to use
-OUTPUT_NAME = OUTPUT_DIR.split("/").last
+OUTPUT_NAME = Konbata::OUTPUT_DIR.split("/").last
 UPLOAD_NAME = UPLOAD_DIR.split("/").last
-CONVERTED_FILES = Rake::FileList.new("#{OUTPUT_DIR}/*.imscc")
+CONVERTED_FILES = Rake::FileList.new("#{Konbata::OUTPUT_DIR}/*.imscc")
 
 ##
 # Creates rake tasks that can be ran from the gem.
@@ -23,7 +22,7 @@ CONVERTED_FILES = Rake::FileList.new("#{OUTPUT_DIR}/*.imscc")
 
 def source_for_upload_log(upload_log)
   CONVERTED_FILES.detect do |f|
-    path = upload_log.pathmap("%{^#{UPLOAD_DIR}/,#{OUTPUT_DIR}/}X")
+    path = upload_log.pathmap("%{^#{UPLOAD_DIR}/,#{Konbata::OUTPUT_DIR}/}X")
     f.ext("") == path
   end
 end
@@ -64,7 +63,7 @@ module Konbata
 
         desc "Destroy output folder."
         task :clean do
-          remove_entry_secure(OUTPUT_DIR)
+          remove_entry_secure(Konbata::OUTPUT_DIR)
         end
       end
     end


### PR DESCRIPTION
Imported senkyoshi content.
Renamed course.rb to canvas_course.rb to distinguish between the UploadCourse used for uploading to Canvas and the CanvasCourse used for creating the imscc.
Known issues: Units that surpass the character limit are not importing correctly.