### PR TITLE
Add Spec for Absolutely Positioned Elements

### DIFF
--- a/spec/fixtures/source_file_html/source_file.html
+++ b/spec/fixtures/source_file_html/source_file.html
@@ -1,4 +1,4 @@
 <html>
   Source file converted to HTML
-  <img src="cat.jpg">
+  <img src="cat.jpg" style="position: absolute;">
 </html>

--- a/spec/models/source_file_spec.rb
+++ b/spec/models/source_file_spec.rb
@@ -83,6 +83,10 @@ describe Konbata do
           assert_includes(image_tag["src"], "source_file_images")
         end
       end
+
+      it "should remove absolute positioning CSS" do
+        refute_includes(@canvas_course.pages.first.body, "position: absolute;")
+      end
     end
 
     describe "_copy_html_images" do


### PR DESCRIPTION
Forgot to include this with the previous PR that fixed absolutely positioned images.