### PR TITLE
Fix Bug in Rake Clean Task

### DIFF
--- a/lib/konbata/tasks.rb
+++ b/lib/konbata/tasks.rb
@@ -24,7 +24,9 @@ module Konbata
 
         desc "Destroy output folder."
         task :clean do
-          remove_entry_secure(OUTPUT_DIR)
+          if Dir.exist?(Konbata::OUTPUT_DIR)
+            remove_entry_secure(Konbata::OUTPUT_DIR)
+          end
         end
       end
     end


### PR DESCRIPTION
Running `rake konbata:clean` would throw an error if the output `canvas` folder didn't exist. This changes the task so it checks for the existence of the folder before trying to delete it.