### PR TITLE
Add Basic SCORM Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
 
 # Konbata Converter
 
-Konbata converts .doc and .docx files into Canvas .imscc packages.
+Konbata converts .doc and .docx files into Canvas .imscc packages. It also offers basic support for converting SCORM packages.
 
 ## Installation
 
-Konbata depends on LibreOffice for source file conversion. You'll need to download and install it to your machine. You can do so [here](https://www.libreoffice.org/download/download/). Konbata was tested against LibreOffice version 5.3.0.
+Konbata depends on LibreOffice for conversion of .doc and .docx source files. You'll need to download and install it to your machine. You can do so [here](https://www.libreoffice.org/download/download/). Konbata was tested against LibreOffice version 5.3.0.
 
 After checking out the repo, run `bundle install` to install dependencies.
 
@@ -42,18 +42,22 @@ Create a `konbata.yml` file and add credentials:
 # This can be :self, :default, or an ID.
 :account_id: <account id>
 
+:scorm_url: <scorm manager url>
+:scorm_launch_url: <scorm launch url>
+:scorm_shared_auth: <scorm manager token>
+
 # Leave empty for DEFAULT_TIMEOUT
 :request_timeout: <request timeout seconds>
 ```
 
 ## Usage
 
-#### Source Files
-Add any files you want to process into the `sources` directory inside the Konbata project directory. It expects a specific directory structure for the source files that are added to that `sources` folder.
+#### .doc/.docx Files
+Add any .doc or .docx files you want to process into the `sources` directory inside the Konbata project directory. It expects a specific directory structure for the source files that are added to that `sources` folder.
 
 Each directory placed in the `sources` folder should include in it's name 2 pieces of data:
-  - "Course - ####," (e.g. "Course - ABC123"). "####" will be used recognized as a course identifier.
-  - "Volume " followed by a volume number (e.g. "Volume 1"). The number will be recognized as a volume number.
+  - "Course - ####," (e.g. "Course - ABC123"). "####" will be used as a course identifier.
+  - "Volume " followed by a volume number (e.g. "Volume 1"). The number will be used as a volume number.
 
 Each course detected will be turned into a separate .imscc file.
 
@@ -70,7 +74,11 @@ For each file found that matches one of the above patterns, Konbata will generat
 
 Along with generating Canvas pages, the original source files will be added to the Canvas course's files and will be available in the Files section.
 
-Do not place files at the top level inside the `sources` directory or Konbata will not complete processing.
+#### SCORM Packages
+
+Any `.zip` files placed at the top level of the `sources` directory will be processed as SCORM packages.
+
+Only basic support for SCORM packages is available as of right now. For each SCORM zip found, Konbata will create a skeleton Canvas course and create an .imscc file for that course. It will add the original SCORM package to the course's files and, when running the `upload` command, Konbata will also make the appropriate calls to upload the SCORM package to the SCORM manager designated in the `konbata.yml` file.
 
 #### Running
 
@@ -78,7 +86,8 @@ To run Konbata, use the following Rake tasks:
 
 Convert files:
 ```sh
-rake konbata:imscc
+rake konbata:doc # For processing .doc and .docx files.
+rake konbata:scorm # For processing SCORM packages.
 ```
 
 Delete the entire output folder:

--- a/konbata.example.yml
+++ b/konbata.example.yml
@@ -15,5 +15,9 @@
 # This can be :self, :default, or an ID.
 :account_id: <account id>
 
+:scorm_url: <scorm manager url>
+:scorm_launch_url: <scorm launch url>
+:scorm_shared_auth: <scorm manager token>
+
 # Leave empty for DEFAULT_TIMEOUT
 :request_timeout: <request timeout seconds>

--- a/lib/konbata.rb
+++ b/lib/konbata.rb
@@ -57,7 +57,9 @@ module Konbata
     end
   end
 
-  def self.upload_scorm
+  def self.convert_scorm
+    FileUtils.mkdir_p(OUTPUT_DIR)
+
     scorm_package_paths = Dir.glob("#{INPUT_DIR}/*.zip")
 
     scorm_package_paths.each do |package_path|

--- a/lib/konbata.rb
+++ b/lib/konbata.rb
@@ -40,7 +40,7 @@ module Konbata
     "aj_" + SecureRandom.hex(32)
   end
 
-  def self.convert_courses
+  def self.convert_docs
     FileUtils.mkdir_p(OUTPUT_DIR)
 
     docs = Dir.glob("#{INPUT_DIR}/**/*.{doc,docx}")
@@ -50,7 +50,7 @@ module Konbata
     course_structures.each_with_index do |(course_code, volumes), index|
       Konbata::Reporter.start_course(course_code, index, course_structures.size)
 
-      course = Konbata::Course.new(course_code, volumes)
+      course = Konbata::DocCourse.new(course_code, volumes)
       create_imscc(course)
 
       Konbata::Reporter.complete_course(course_code)

--- a/lib/konbata.rb
+++ b/lib/konbata.rb
@@ -63,7 +63,7 @@ module Konbata
     scorm_package_paths = Dir.glob("#{INPUT_DIR}/*.zip")
     scorm_package_paths.each do |package_path|
       # Formats path to not have any spaces as the Scorm upload can't handle it
-      formatted_path = package_path.gsub(/[ ]/, "_")
+      formatted_path = package_path.gsub(/\s/, "_")
       if formatted_path != package_path
         File.rename(package_path, formatted_path)
         package_path = formatted_path

--- a/lib/konbata.rb
+++ b/lib/konbata.rb
@@ -57,23 +57,22 @@ module Konbata
     end
   end
 
-  def self.upload_scorm
+  def self.create_scorm
+    FileUtils.mkdir_p(OUTPUT_DIR)
     scorm_package_paths = Dir.glob("#{INPUT_DIR}/*.zip")
 
     scorm_package_paths.each do |package_path|
       course = ScormCourse.new(package_path)
       create_imscc(course)
     end
-
-    # Add scorm package to scorm player
   end
 
   def self.create_imscc(course)
     imscc = CanvasCc::CanvasCC::CartridgeCreator.
       new(course.canvas_course).
       create(Dir.mktmpdir)
-
-    FileUtils.cp(imscc, OUTPUT_DIR)
+    # Renaming imscc file name to match source file since CanvasCC changes it
+    FileUtils.cp(imscc, "#{OUTPUT_DIR}/#{course.canvas_course.title}.imscc")
   end
 
   ##
@@ -106,9 +105,9 @@ module Konbata
     end
   end
 
-  def self.initialize_course(canvas_file_path)
+  def self.initialize_course(canvas_file_path, source_for_imscc)
     metadata = Konbata::UploadCourse.metadata_from_file(canvas_file_path)
     course = Konbata::UploadCourse.from_metadata(metadata)
-    course.upload_content(canvas_file_path)
+    course.upload_content(canvas_file_path, source_for_imscc)
   end
 end

--- a/lib/konbata.rb
+++ b/lib/konbata.rb
@@ -18,7 +18,8 @@ require "zip"
 
 require "konbata/configuration"
 require "konbata/reporter"
-require "konbata/models/canvas_course"
+require "konbata/models/doc_course"
+require "konbata/models/scorm_course"
 require "konbata/models/upload_course"
 
 module Konbata
@@ -54,6 +55,17 @@ module Konbata
 
       Konbata::Reporter.complete_course(course_code)
     end
+  end
+
+  def self.upload_scorm
+    scorm_package_paths = Dir.glob("#{INPUT_DIR}/*.zip")
+
+    scorm_package_paths.each do |package_path|
+      course = ScormCourse.new(package_path)
+      create_imscc(course)
+    end
+
+    # Add scorm package to scorm player
   end
 
   def self.create_imscc(course)

--- a/lib/konbata/configuration.rb
+++ b/lib/konbata/configuration.rb
@@ -20,6 +20,9 @@ module Konbata
     attr_reader :canvas_url
     attr_reader :canvas_token
     attr_reader :account_id
+    attr_reader :scorm_url
+    attr_reader :scorm_launch_url
+    attr_reader :scorm_shared_auth
     attr_reader :request_timeout
     attr_reader :libre_office_path
     DEFAULT_TIMEOUT = 1_800 # 30 minutes
@@ -28,6 +31,9 @@ module Konbata
       @canvas_url = Configuration._config[:canvas_url]
       @canvas_token = Configuration._config[:canvas_token]
       @account_id = Configuration._config[:account_id] || :self
+      @scorm_url = Configuration._config[:scorm_url]
+      @scorm_launch_url = Configuration._config[:scorm_launch_url]
+      @scorm_shared_auth = Configuration._config[:scorm_shared_auth]
       @request_timeout =
         Configuration._config[:request_timeout] || DEFAULT_TIMEOUT
       @libre_office_path = Configuration._config[:libre_office_path]

--- a/lib/konbata/models/canvas_course.rb
+++ b/lib/konbata/models/canvas_course.rb
@@ -19,7 +19,7 @@ module Konbata
   class CanvasCourse
     def self.create(title)
       canvas_course = CanvasCc::CanvasCC::Models::Course.new
-      canvas_course.identifier = title
+      canvas_course.identifier = Konbata.create_random_hex
       canvas_course.course_code = title
       canvas_course.title = title
 

--- a/lib/konbata/models/canvas_module.rb
+++ b/lib/konbata/models/canvas_module.rb
@@ -16,7 +16,7 @@
 require "canvas_cc"
 
 module Konbata
-  class Module
+  class CanvasModule
     def self.create(volume)
       canvas_module = CanvasCc::CanvasCC::Models::CanvasModule.new
       canvas_module.identifier = Konbata.create_random_hex

--- a/lib/konbata/models/canvas_module_item.rb
+++ b/lib/konbata/models/canvas_module_item.rb
@@ -13,17 +13,17 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-require "canvas_cc"
-
 module Konbata
-  class CanvasCourse
-    def self.create(title)
-      canvas_course = CanvasCc::CanvasCC::Models::Course.new
-      canvas_course.identifier = title
-      canvas_course.course_code = title
-      canvas_course.title = title
+  class CanvasModuleItem
+    def self.create(title, identifierref)
+      module_item = CanvasCc::CanvasCC::Models::ModuleItem.new
+      module_item.title = title
+      module_item.identifier = Konbata.create_random_hex
+      module_item.content_type = "WikiPage"
+      module_item.identifierref = identifierref
+      module_item.workflow_state = "active"
 
-      canvas_course
+      module_item
     end
   end
 end

--- a/lib/konbata/models/doc_course.rb
+++ b/lib/konbata/models/doc_course.rb
@@ -1,0 +1,93 @@
+# Copyright (C) 2017  Atomic Jolt
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+require "canvas_cc"
+require "konbata/reporter"
+require "konbata/models/canvas_course"
+require "konbata/models/canvas_module"
+require "konbata/models/cover_page_file"
+require "konbata/models/glossary_file"
+require "konbata/models/unit_file"
+
+module Konbata
+  class Course
+    attr_reader :canvas_course
+
+    def initialize(course_code, volumes)
+      @volumes = volumes
+      @canvas_course = _create_canvas_course(course_code)
+    end
+
+    private
+
+    def _create_canvas_course(course_code)
+      canvas_course = CanvasCourse.create(course_code)
+
+      _instantiate_source_files
+      _add_raw_source_files(canvas_course)
+      _convert_source_files(canvas_course)
+
+      canvas_course
+    end
+
+    def _instantiate_source_files
+      @volumes.each do |volume, file_paths|
+        file_paths.map! do |file_path|
+          if file_path[/front/i]
+            Konbata::CoverPageFile.new(file_path, volume)
+          elsif file_path[/glos/i]
+            Konbata::GlossaryFile.new(file_path, volume)
+          elsif file_path[/U\d+/i]
+            Konbata::UnitFile.new(file_path, volume)
+          end
+        end.compact!
+      end
+    end
+
+    def _add_raw_source_files(canvas_course)
+      @volumes.each do |_, source_files|
+        source_files.each do |source_file|
+          canvas_course.files << source_file.canvas_file
+        end
+      end
+    end
+
+    def _convert_source_files(canvas_course)
+      @volumes.each do |volume, source_files|
+        canvas_module = Konbata::Module.create(volume)
+
+        source_files.each do |source_file|
+          source_file.convert(canvas_course, canvas_module)
+
+          Konbata::Reporter.complete_source_file(
+            _source_file_index(source_file),
+            _source_files_count,
+          )
+        end
+
+        canvas_course.canvas_modules << canvas_module
+      end
+    end
+
+    def _source_files_count
+      @volumes.reduce(0) { |total, (_volume, files)| total + files.size }
+    end
+
+    def _source_file_index(source_file)
+      @all_files ||= @volumes.reduce([]) { |all, (_volume, files)| all + files }
+      @all_files.index(source_file)
+    end
+  end
+end

--- a/lib/konbata/models/doc_course.rb
+++ b/lib/konbata/models/doc_course.rb
@@ -22,7 +22,7 @@ require "konbata/models/glossary_file"
 require "konbata/models/unit_file"
 
 module Konbata
-  class Course
+  class DocCourse
     attr_reader :canvas_course
 
     def initialize(course_code, volumes)
@@ -66,7 +66,7 @@ module Konbata
 
     def _convert_source_files(canvas_course)
       @volumes.each do |volume, source_files|
-        canvas_module = Konbata::Module.create(volume)
+        canvas_module = Konbata::CanvasModule.create(volume)
 
         source_files.each do |source_file|
           source_file.convert(canvas_course, canvas_module)

--- a/lib/konbata/models/scorm_course.rb
+++ b/lib/konbata/models/scorm_course.rb
@@ -13,15 +13,27 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-require "canvas_cc"
+require "konbata/models/canvas_course"
+require "konbata/models/scorm_file"
 
 module Konbata
-  class CanvasCourse
-    def self.create(title)
-      canvas_course = CanvasCc::CanvasCC::Models::Course.new
-      canvas_course.identifier = title
-      canvas_course.course_code = title
-      canvas_course.title = title
+  class ScormCourse
+    attr_reader :canvas_course
+
+    def initialize(package_path)
+      @package_path = package_path
+      # TODO: Consider using <title> node for course name.
+      @course_title = File.basename(package_path, ".zip")
+      @canvas_course = _create_canvas_course
+    end
+
+    private
+
+    def _create_canvas_course
+      canvas_course = CanvasCourse.create(@course_title)
+      scorm_file = ScormFile.new(@package_path)
+
+      canvas_course.files << scorm_file.canvas_file
 
       canvas_course
     end

--- a/lib/konbata/models/scorm_file.rb
+++ b/lib/konbata/models/scorm_file.rb
@@ -14,16 +14,28 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 module Konbata
-  class ModuleItem
-    def self.create(title, identifierref)
-      module_item = CanvasCc::CanvasCC::Models::ModuleItem.new
-      module_item.title = title
-      module_item.identifier = Konbata.create_random_hex
-      module_item.content_type = "WikiPage"
-      module_item.identifierref = identifierref
-      module_item.workflow_state = "active"
+  class ScormFile
+    attr_reader :canvas_file
 
-      module_item
+    def initialize(file_path)
+      @file_path = file_path
+      @canvas_file = _create_canvas_file
+    end
+
+    private
+
+    ##
+    # Creates and populates a canvas_cc CanvasFile.
+    ##
+    def _create_canvas_file
+      canvas_file = CanvasCc::CanvasCC::Models::CanvasFile.new
+
+      canvas_file.identifier = Konbata.create_random_hex
+      canvas_file.file_location = @file_path
+      canvas_file.hidden = false
+      canvas_file.file_path = File.basename(@file_path)
+
+      canvas_file
     end
   end
 end

--- a/lib/konbata/models/source_file.rb
+++ b/lib/konbata/models/source_file.rb
@@ -15,7 +15,7 @@
 
 require "canvas_cc"
 require "libreconv"
-require "konbata/models/module_item"
+require "konbata/models/canvas_module_item"
 
 module Konbata
   class SourceFile

--- a/lib/konbata/models/source_file.rb
+++ b/lib/konbata/models/source_file.rb
@@ -49,7 +49,7 @@ module Konbata
       page.page_name = @title
       page.body = _html_text(html_output_dir)
 
-      module_item = Konbata::ModuleItem.create(
+      module_item = Konbata::CanvasModuleItem.create(
         @title,
         page.identifier,
       )

--- a/lib/konbata/models/upload_course.rb
+++ b/lib/konbata/models/upload_course.rb
@@ -104,9 +104,11 @@ module Konbata
       upload_to_s3(migration, filename)
       puts "Done uploading: #{name}"
 
-      puts "Creating Scorm: #{name}"
-      upload_scorm_package(source_for_imscc, @course_resource.id)
-      puts "Done creating scorm: #{name}"
+      if File.exist?(source_for_imscc)
+        puts "Creating Scorm: #{name}"
+        upload_scorm_package(source_for_imscc, @course_resource.id)
+        puts "Done creating scorm: #{name}"
+      end
     end
 
     def upload_to_s3(migration, filename)

--- a/lib/konbata/models/upload_course.rb
+++ b/lib/konbata/models/upload_course.rb
@@ -68,10 +68,28 @@ module Konbata
     end
 
     ##
+    # Uploads a scorm package to scorm manager specified in senkyoshi.yml
+    # config file
+    ##
+    def upload_scorm_package(scorm_zip, course_id)
+      File.open(scorm_zip, "rb") do |file|
+        RestClient.post(
+          "#{Konbata.configuration.scorm_url}/api/scorm_courses",
+          {
+            oauth_consumer_key: "scorm-player",
+            lms_course_id: course_id,
+            file: file,
+          },
+          SharedAuthorization: Konbata.configuration.scorm_shared_auth,
+        )
+      end
+    end
+
+    ##
     # Create a migration for the course
     # and upload the imscc file to be imported into the course
     ##
-    def upload_content(filename)
+    def upload_content(filename, source_for_imscc)
       client = UploadCourse.client
       name = File.basename(filename)
       # Create a migration for the course and get S3 upload authorization
@@ -85,6 +103,10 @@ module Konbata
       puts "Uploading: #{name}"
       upload_to_s3(migration, filename)
       puts "Done uploading: #{name}"
+
+      puts "Creating Scorm: #{name}"
+      upload_scorm_package(source_for_imscc, @course_resource.id)
+      puts "Done creating scorm: #{name}"
     end
 
     def upload_to_s3(migration, filename)

--- a/lib/konbata/models/upload_course.rb
+++ b/lib/konbata/models/upload_course.rb
@@ -68,7 +68,7 @@ module Konbata
     end
 
     ##
-    # Uploads a scorm package to scorm manager specified in senkyoshi.yml
+    # Uploads a scorm package to scorm manager specified in konbata.yml
     # config file
     ##
     def upload_scorm_package(scorm_zip, course_id)

--- a/lib/konbata/tasks.rb
+++ b/lib/konbata/tasks.rb
@@ -63,7 +63,12 @@ module Konbata
           Konbata.convert_courses
         end
 
-        desc "Upload converted files to canvas"
+        desc "Find and upload SCORM packages to Canvas"
+        task :scorm do
+          Konbata.upload_scorm
+        end
+
+        desc "Upload .imscc files to canvas"
         task upload: CONVERTED_FILES.pathmap(
           "%{^#{OUTPUT_NAME}/,#{UPLOAD_DIR}/}X.txt",
         )

--- a/lib/konbata/tasks.rb
+++ b/lib/konbata/tasks.rb
@@ -63,9 +63,9 @@ module Konbata
           Konbata.convert_courses
         end
 
-        desc "Find and upload SCORM packages to Canvas"
+        desc "Find and process SCORM packages"
         task :scorm do
-          Konbata.upload_scorm
+          Konbata.convert_scorm
         end
 
         desc "Upload .imscc files to canvas"

--- a/lib/konbata/tasks.rb
+++ b/lib/konbata/tasks.rb
@@ -36,14 +36,6 @@ CONVERTED_FILES = Rake::FileList.new("#{Konbata::OUTPUT_DIR}/*.imscc")
 #
 ##
 
-def source_for_imscc(imscc_file)
-  SOURCE_FILES.detect do |f|
-    path =
-      imscc_file.pathmap("%{^#{Konbata::OUTPUT_DIR}/,#{Konbata::INPUT_DIR}/}X")
-    f.ext("") == path
-  end
-end
-
 def source_for_upload_log(upload_log)
   CONVERTED_FILES.detect do |f|
     path = upload_log.pathmap("%{^#{UPLOAD_DIR}/,#{Konbata::OUTPUT_DIR}/}X")
@@ -86,7 +78,7 @@ module Konbata
 
         rule ".txt" => [->(f) { source_for_upload_log(f) }, UPLOAD_NAME] do |t|
           make_directories(t.name, UPLOAD_DIR)
-          Konbata.initialize_course(t.source, source_for_imscc(t.source))
+          Konbata.initialize_course(t.source)
           log_file(t.name)
         end
 

--- a/lib/konbata/tasks.rb
+++ b/lib/konbata/tasks.rb
@@ -32,7 +32,7 @@ CONVERTED_FILES = Rake::FileList.new("#{Konbata::OUTPUT_DIR}/*.imscc")
 # Add this to your Rakefile
 #
 #   require "konbata/tasks"
-#   Senkyoshi::Tasks.install_tasks
+#   Konbata::Tasks.install_tasks
 #
 ##
 
@@ -60,8 +60,8 @@ module Konbata
     def self.install_tasks
       namespace :konbata do
         desc "Generate Canvas courses from folders in source directory."
-        task :imscc do
-          Konbata.convert_courses
+        task :doc do
+          Konbata.convert_docs
         end
 
         desc "Find and process SCORM packages"

--- a/lib/konbata/tasks.rb
+++ b/lib/konbata/tasks.rb
@@ -23,7 +23,6 @@ UPLOAD_DIR = "uploaded".freeze
 ## of the folder name for the script below to use
 OUTPUT_NAME = Konbata::OUTPUT_DIR.split("/").last
 UPLOAD_NAME = UPLOAD_DIR.split("/").last
-SOURCE_FILES = Rake::FileList.new("#{Konbata::INPUT_DIR}/*.zip")
 CONVERTED_FILES = Rake::FileList.new("#{Konbata::OUTPUT_DIR}/*.imscc")
 
 ##

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,57 @@
+# Copyright (C) 2017  Atomic Jolt
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+require_relative "helpers/spec_helper"
+require "konbata/configuration"
+
+describe Konbata do
+  describe "Configuration" do
+    before do
+      @config = Konbata::Configuration.new
+    end
+
+    it "should have a canvas_url attribute" do
+      assert_respond_to(@config, :canvas_url)
+    end
+
+    it "should have a canvas_token attribute" do
+      assert_respond_to(@config, :canvas_token)
+    end
+
+    it "should have a account_id attribute" do
+      assert_respond_to(@config, :account_id)
+    end
+
+    it "should have a scorm_url attribute" do
+      assert_respond_to(@config, :scorm_url)
+    end
+
+    it "should have a scorm_launch_url attribute" do
+      assert_respond_to(@config, :scorm_launch_url)
+    end
+
+    it "should have a scorm_shared_auth attribute" do
+      assert_respond_to(@config, :scorm_shared_auth)
+    end
+
+    it "should have a request_timeout attribute" do
+      assert_respond_to(@config, :request_timeout)
+    end
+
+    it "should have a libre_office_path attribute" do
+      assert_respond_to(@config, :libre_office_path)
+    end
+  end
+end

--- a/spec/helpers/spec_helper.rb
+++ b/spec/helpers/spec_helper.rb
@@ -18,7 +18,7 @@ require "minitest/reporters"
 Minitest::Reporters.use!
 
 require "konbata"
-require_relative "../mocks/mock_course"
+require_relative "../mocks/mock_doc_course"
 require_relative "../mocks/mock_cover_page_file"
 require_relative "../mocks/mock_glossary_file"
 require_relative "../mocks/mock_source_file"

--- a/spec/mocks/mock_doc_course.rb
+++ b/spec/mocks/mock_doc_course.rb
@@ -13,31 +13,18 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-require_relative "../helpers/spec_helper"
-
-describe Konbata do
-  describe "Module" do
-    describe "self.create" do
-      before do
-        @volume = "3"
-        @module = Konbata::Module.create(@volume)
-      end
-
-      it "should return a canvas_cc module" do
-        assert(@module.is_a?(CanvasCc::CanvasCC::Models::CanvasModule))
-      end
-
-      it "should give the module an identifier" do
-        refute_nil(@module.identifier)
-      end
-
-      it "should give the module a title" do
-        assert_equal("Volume 3", @module.title)
-      end
-
-      it "should give the module a workflow state of 'active'" do
-        assert_equal("active", @module.workflow_state)
-      end
+class MockDocCourse < Konbata::DocCourse
+  def _instantiate_source_files
+    @volumes.each do |volume, file_paths|
+      file_paths.map! do |file_path|
+        if file_path[/front/i]
+          MockCoverPageFile.new(file_path, volume)
+        elsif file_path[/glos/i]
+          MockGlossaryFile.new(file_path, volume)
+        elsif file_path[/U\d+/i]
+          MockUnitFile.new(file_path, volume)
+        end
+      end.compact!
     end
   end
 end

--- a/spec/models/canvas_course_spec.rb
+++ b/spec/models/canvas_course_spec.rb
@@ -14,25 +14,30 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 require_relative "../helpers/spec_helper"
+require "konbata/models/canvas_course"
 
 describe Konbata do
-  describe "GlossaryFile" do
-    describe "initialize" do
+  describe "CanvasCourse" do
+    describe "#create" do
       before do
-        file_path = fixture_path("glos.doc")
-        @volume = "3"
-
-        @cover_page_file = MockGlossaryFile.new(file_path, @volume)
-        @canvas_course = CanvasCc::CanvasCC::Models::Course.new
-        @canvas_module = Konbata::CanvasModule.create(@volume)
-        @cover_page_file.convert(@canvas_course, @canvas_module)
+        @title = "Test Course"
+        @canvas_course = Konbata::CanvasCourse.create(@title)
       end
 
-      it "should create a title" do
-        assert_equal(
-          "Glossary (Vol. #{@volume})",
-          @canvas_module.module_items.first.title,
-        )
+      it "should return a canvas_cc course" do
+        assert_kind_of(CanvasCc::CanvasCC::Models::Course, @canvas_course)
+      end
+
+      it "should give the canvas_cc course an identifier" do
+        refute_nil(@canvas_course.identifier)
+      end
+
+      it "should give the canvas_cc course a course code" do
+        assert_equal(@title, @canvas_course.course_code)
+      end
+
+      it "should give the canvas_cc course a title" do
+        assert_equal(@title, @canvas_course.title)
       end
     end
   end

--- a/spec/models/canvas_module_item_spec.rb
+++ b/spec/models/canvas_module_item_spec.rb
@@ -21,7 +21,7 @@ describe Konbata do
       before do
         @title = "Test Module Item"
         @identifierref = Konbata.create_random_hex
-        @module_item = Konbata::ModuleItem.create(@title, @identifierref)
+        @module_item = Konbata::CanvasModuleItem.create(@title, @identifierref)
       end
 
       it "should return a canvas_cc module item" do

--- a/spec/models/canvas_module_spec.rb
+++ b/spec/models/canvas_module_spec.rb
@@ -13,18 +13,31 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-class MockCourse < Konbata::Course
-  def _instantiate_source_files
-    @volumes.each do |volume, file_paths|
-      file_paths.map! do |file_path|
-        if file_path[/front/i]
-          MockCoverPageFile.new(file_path, volume)
-        elsif file_path[/glos/i]
-          MockGlossaryFile.new(file_path, volume)
-        elsif file_path[/U\d+/i]
-          MockUnitFile.new(file_path, volume)
-        end
-      end.compact!
+require_relative "../helpers/spec_helper"
+
+describe Konbata do
+  describe "Module" do
+    describe "self.create" do
+      before do
+        @volume = "3"
+        @module = Konbata::CanvasModule.create(@volume)
+      end
+
+      it "should return a canvas_cc module" do
+        assert(@module.is_a?(CanvasCc::CanvasCC::Models::CanvasModule))
+      end
+
+      it "should give the module an identifier" do
+        refute_nil(@module.identifier)
+      end
+
+      it "should give the module a title" do
+        assert_equal("Volume 3", @module.title)
+      end
+
+      it "should give the module a workflow state of 'active'" do
+        assert_equal("active", @module.workflow_state)
+      end
     end
   end
 end

--- a/spec/models/cover_page_file_spec.rb
+++ b/spec/models/cover_page_file_spec.rb
@@ -24,7 +24,7 @@ describe Konbata do
 
         @cover_page_file = MockCoverPageFile.new(file_path, @volume)
         @canvas_course = CanvasCc::CanvasCC::Models::Course.new
-        @canvas_module = Konbata::Module.create(@volume)
+        @canvas_module = Konbata::CanvasModule.create(@volume)
         @cover_page_file.convert(@canvas_course, @canvas_module)
       end
 

--- a/spec/models/doc_course_spec.rb
+++ b/spec/models/doc_course_spec.rb
@@ -28,28 +28,10 @@ describe Konbata do
       ],
     }
 
-    @course = MockCourse.new(@course_code, volumes)
+    @course = MockDocCourse.new(@course_code, volumes)
   end
 
   describe "Course" do
-    describe "_create_canvas_course" do
-      it "should return a canvas_cc course" do
-        assert(@course.canvas_course.is_a?(CanvasCc::CanvasCC::Models::Course))
-      end
-
-      it "should give the canvas_cc course an identifier" do
-        assert_equal(@course_code, @course.canvas_course.identifier)
-      end
-
-      it "should give the canvas_cc course a course code" do
-        assert_equal(@course_code, @course.canvas_course.course_code)
-      end
-
-      it "should give the canvas_cc course a title" do
-        assert_equal(@course_code, @course.canvas_course.title)
-      end
-    end
-
     describe "_add_raw_source_files" do
       it "should populate canvas_cc course with files" do
         assert_equal(3, @course.canvas_course.files.size)

--- a/spec/models/scorm_course_spec.rb
+++ b/spec/models/scorm_course_spec.rb
@@ -14,25 +14,21 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 require_relative "../helpers/spec_helper"
+require "konbata/models/scorm_course"
 
 describe Konbata do
-  describe "GlossaryFile" do
-    describe "initialize" do
+  describe "ScormCourse" do
+    describe "#_create_canvas_course" do
       before do
-        file_path = fixture_path("glos.doc")
-        @volume = "3"
-
-        @cover_page_file = MockGlossaryFile.new(file_path, @volume)
-        @canvas_course = CanvasCc::CanvasCC::Models::Course.new
-        @canvas_module = Konbata::CanvasModule.create(@volume)
-        @cover_page_file.convert(@canvas_course, @canvas_module)
+        @scorm_course = Konbata::ScormCourse.new("sources/Test_Package.zip")
       end
 
-      it "should create a title" do
-        assert_equal(
-          "Glossary (Vol. #{@volume})",
-          @canvas_module.module_items.first.title,
-        )
+      it "should return a canvas_course" do
+        refute_nil(@scorm_course.canvas_course)
+      end
+
+      it "should add the SCORM file to the canvas_course" do
+        assert_equal(1, @scorm_course.canvas_course.files.size)
       end
     end
   end

--- a/spec/models/scorm_file_spec.rb
+++ b/spec/models/scorm_file_spec.rb
@@ -1,0 +1,54 @@
+# Copyright (C) 2017  Atomic Jolt
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+require_relative "../helpers/spec_helper"
+require "konbata/models/scorm_file"
+
+describe Konbata do
+  describe "ScormFile" do
+    before do
+      @file_path = "sources/Test_Package.zip"
+      @scorm_file = Konbata::ScormFile.new(@file_path)
+    end
+
+    describe "#_create_canvas_file" do
+      it "should return a canvas_cc file" do
+        assert_kind_of(
+          CanvasCc::CanvasCC::Models::CanvasFile,
+          @scorm_file.canvas_file,
+        )
+      end
+
+      it "should give the canvas_cc file an identifier" do
+        refute_nil(@scorm_file.canvas_file.identifier)
+      end
+
+      it "should give the canvas_cc file a file location" do
+        assert_equal(@file_path, @scorm_file.canvas_file.file_location)
+      end
+
+      it "should make the canvas_cc file visible" do
+        refute(@scorm_file.canvas_file.hidden)
+      end
+
+      it "should give the canvas_cc file a file path" do
+        assert_equal(
+          File.basename(@file_path),
+          @scorm_file.canvas_file.file_path,
+        )
+      end
+    end
+  end
+end

--- a/spec/models/source_file_spec.rb
+++ b/spec/models/source_file_spec.rb
@@ -23,7 +23,7 @@ describe Konbata do
 
       @source_file = MockSourceFile.new(@file_path, volume)
       @canvas_course = CanvasCc::CanvasCC::Models::Course.new
-      @canvas_module = Konbata::Module.create(volume)
+      @canvas_module = Konbata::CanvasModule.create(volume)
       @source_file.convert(@canvas_course, @canvas_module)
     end
 

--- a/spec/models/unit_file_spec.rb
+++ b/spec/models/unit_file_spec.rb
@@ -24,7 +24,7 @@ describe Konbata do
 
         @cover_page_file = MockUnitFile.new(file_path, @volume)
         @canvas_course = CanvasCc::CanvasCC::Models::Course.new
-        @canvas_module = Konbata::Module.create(@volume)
+        @canvas_module = Konbata::CanvasModule.create(@volume)
         @cover_page_file.convert(@canvas_course, @canvas_module)
       end
 


### PR DESCRIPTION
If there are .zip files in the "sources" directory, they are assumed to be SCORM packages and handled as such. An empty Canvas course is created and the original SCORM package is added to the course Files section. Then, the SCORM package is added to the SCORM player.