### PR TITLE
Hide Course Tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,13 @@ Along with generating Canvas pages, the original source files will be added to t
 
 Any `.zip` files placed at the top level of the `sources` directory will be processed as SCORM packages.
 
-Only basic support for SCORM packages is available as of right now. For each SCORM zip found, Konbata will create a skeleton Canvas course and create an .imscc file for that course. It will add the original SCORM package to the course's files and, when running the `upload` command, Konbata will also make the appropriate calls to upload the SCORM package to the SCORM manager designated in the `konbata.yml` file.
-
-Konbata also adds any PDF files found in the SCORM package to the course's files.
+Only basic support for SCORM packages is available as of right now. For each SCORM zip found, Konbata will do the following:
+  - Create a skeleton Canvas course and create an .imscc file for that course.
+  - Add the original SCORM package to the course's files.
+  - Add any PDF files found in the SCORM package to the course's files.
+  - When running the `upload` command, make the appropriate calls to upload the SCORM package to the SCORM manager designated in the `konbata.yml` file.
+  - Hide all of the course's tabs except for "Home" and "Assignments".
+  - Set the default view to "Assignments".
 
 #### Running
 

--- a/lib/konbata/models/upload_course.rb
+++ b/lib/konbata/models/upload_course.rb
@@ -107,6 +107,7 @@ module Konbata
 
       puts "Uploading: #{name}"
       upload_to_s3(migration, filename)
+      change_tabs_visibility
       puts "Done uploading: #{name}"
 
       if File.exist?(source_for_imscc)
@@ -140,6 +141,59 @@ module Konbata
           )
         end
       end
+    end
+
+    ##
+    # Requests all of the tabs available for a course. Sets hidden to `false`
+    # for any tab in the label whitelist; sets hidden to `true` for all others.
+    # `whitelisted_labels` should be an array of strings or regexps.
+    ##
+    def change_tabs_visibility(whitelisted_labels = nil)
+      whitelisted_labels ||= [/home/i, /assignments/i, /scorm/i]
+      whitelisted_labels.map! { |label| Regexp.new(label) }
+
+      tab_url_base = Konbata.configuration.canvas_url +
+        "/v1/courses/#{@course_resource.id}/tabs"
+
+      tabs = get_tabs(tab_url_base)
+
+      tabs.each do |tab|
+        # Settings and Home tabs can't be changed.
+        next if tab["id"] == "home" || tab["id"] == "settings"
+
+        visible = whitelisted_labels.any? { |label| tab["label"] =~ label }
+
+        change_tab_visibility(tab, visible, tab_url_base)
+      end
+    end
+
+    ##
+    # Gets the tabs from the given Canvas URL.
+    ##
+    def get_tabs(tab_url_base)
+      RestClient.get(
+        tab_url_base,
+        Authorization: "Bearer #{Konbata.configuration.canvas_token}",
+      ) do |response|
+        JSON.parse(response.body)
+      end
+    end
+
+    ##
+    # Issues a PUT request to Canvas using the given URL and sets the given
+    # tabs hidden attribute to true or false.
+    ##
+    def change_tab_visibility(tab, visible, tab_url_base)
+      RestClient.put(
+        tab_url_base + "/#{tab['id']}",
+        {
+          hidden: !visible,
+        },
+        Authorization: "Bearer #{Konbata.configuration.canvas_token}",
+      )
+    rescue RestClient::BadRequest => e
+      puts "WARNING: Failed to update tab #{tab['label']} for course " \
+      "#{@course_resource.id}. Error: #{e}"
     end
 
     ##


### PR DESCRIPTION
After creating the course, a series of API calls hides all tabs for the course except for Home and Assignments.

My understanding is that we also wanted to make the SCORM Player tab visible. I included the SCORM player tab in the list of tabs to display, but it doesn't look like Canvas allows you to change it's visibility.